### PR TITLE
add @bstellato and @gbanjac to feedstock maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,3 +77,5 @@ extra:
   recipe-maintainers:
     - dougalsutherland
     - h-vetinari
+    - bstellato
+    - gbanjac


### PR DESCRIPTION
As discussed in oxfordcontrol/osqp-python#32.